### PR TITLE
商品一覧サーバー　商品詳細リンク記述済み　8/17 村上

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,13 +28,16 @@ class ItemsController < ApplicationController
 
   def get_category_children
     @category_children = Category.find_by(id: params[:parent_name], ancestry: nil).children
- end
+  end
 
 
- def get_category_grandchildren
-    @category_grandchildren = Category.find("#{params[:child_id]}").children
- end
-
+  def get_category_grandchildren
+      @category_grandchildren = Category.find("#{params[:child_id]}").children
+  end
+  
+  def show
+     
+  end
 
   def create
     @item = Item.new(item_params)

--- a/app/views/items/_items_top.html.haml
+++ b/app/views/items/_items_top.html.haml
@@ -5,15 +5,13 @@
     
   %section.pickupContainer
     %h2.head
-      新規投稿商品
+      新規出品商品
     .productBox
       .productHead
-        = link_to "#", class: "link" do
-          %h3.title 新規投稿商品
       .productLists
         - @items_index.each do |item|
           .productList
-            = link_to "#", class:"link"do
+            = link_to item_path(item), class:"link"do
               %figure.productList--img
                 = image_tag item.images[0].image.url, size:"250x200" , alt:"商品写真"
             .productList--body
@@ -41,120 +39,116 @@
     .productBoxes
       .productBox
         .productHead
-          = link_to "#", class:"link" do
-            %h3.topic
-              レディース
-            .productList
-              - if @last_ladies_item == nil
-                %h3
-                  このカテゴリの新規投稿商品はありません。
-              - else
-                = link_to "#", class:"link" do
-                  %figure.productList--img
-                    = image_tag @last_ladies_item.images[0].image.url,size:"250x200" , alt:"商品写真"
-                .productList--body
-                  %h3.name
-                    = @last_ladies_item.name
-                  .details
-                    %ul
-                      %li
-                        = @last_ladies_item.price
-                      .en
-                      円
-                      %li
-                    %p.tax
-                      (税込)
-                -if @last_ladies_item.buyer_id.present?
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner
-                      SOLD
+          %h3.topic
+            レディース
+          .productList
+            - if @last_ladies_item == nil
+              %h3
+                このカテゴリの新規投稿商品はありません。
+            - else
+              = link_to item_path(@items), class:"link" do
+                %figure.productList--img
+                  = image_tag @last_ladies_item.images[0].image.url,size:"250x200" , alt:"商品写真"
+              .productList--body
+                %h3.name
+                  = @last_ladies_item.name
+                .details
+                  %ul
+                    %li
+                      = @last_ladies_item.price
+                    .en
+                    円
+                    %li
+                  %p.tax
+                    (税込)
+              -if @last_ladies_item.buyer_id.present?
+                .items-box_photo__sold
+                  .items-box_photo__sold__inner
+                    SOLD
 
       .productBox
         .productHead
-          = link_to "#", class:"link" do
-            %h3.topic
-              メンズ
-            .productList
-              - if @last_mens_item == nil
-                %h3
-                  このカテゴリの新規投稿商品はありません。
-              - else
-                = link_to "#", class:"link" do
-                  %figure.productList--img
-                    = image_tag @last_mens_item.images[0].image.url,size:"250x200" , alt:"商品写真"
-                .productList--body
-                  %h3.name
-                    = @last_mens_item.name
-                  .details
-                    %ul
-                      %li
-                        = @last_mens_item.price
-                      .en
-                        円
-                      %li
-                    %p.tax
-                      (税込)
-                -if @last_mens_item.buyer_id.present?
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner
-                      SOLD
+          %h3.topic
+            メンズ
+          .productList
+            - if @last_mens_item == nil
+              %h3
+                このカテゴリの新規投稿商品はありません。
+            - else
+              = link_to item_path(@items), class:"link" do
+                %figure.productList--img
+                  = image_tag @last_mens_item.images[0].image.url,size:"250x200" , alt:"商品写真"
+              .productList--body
+                %h3.name
+                  = @last_mens_item.name
+                .details
+                  %ul
+                    %li
+                      = @last_mens_item.price
+                    .en
+                      円
+                    %li
+                  %p.tax
+                    (税込)
+              -if @last_mens_item.buyer_id.present?
+                .items-box_photo__sold
+                  .items-box_photo__sold__inner
+                    SOLD
       .productBox
         .productHead
-          = link_to "#", class:"link" do
-            %h3.topic
-              ベビー・キッズ
-            .productList
-              - if @last_babies_item == nil
-                %h3
-                  このカテゴリの新規投稿商品はありません。
-              - else
-                = link_to "#", class:"link" do
-                  %figure.productList--img
-                    = image_tag @last_babies_item.images[0].image.url,size:"250x200" , alt:"商品写真"
-                .productList--body
-                  %h3.name
-                    = @last_babies_item.name
-                  .details
-                    %ul
-                      %li
-                        = @last_babies_item.price
-                      .en
-                      円
-                    %p.tax
-                      (税込)
-                -if @last_babies_item.buyer_id.present?
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner
-                      SOLD
+          %h3.topic
+            ベビー・キッズ
+          .productList
+            - if @last_babies_item == nil
+              %h3
+                このカテゴリの新規投稿商品はありません。
+            - else
+              = link_to item_path(@items), class:"link" do
+                %figure.productList--img
+                  = image_tag @last_babies_item.images[0].image.url,size:"250x200" , alt:"商品写真"
+              .productList--body
+                %h3.name
+                  = @last_babies_item.name
+                .details
+                  %ul
+                    %li
+                      = @last_babies_item.price
+                    .en
+                    円
+                  %p.tax
+                    (税込)
+              -if @last_babies_item.buyer_id.present?
+                .items-box_photo__sold
+                  .items-box_photo__sold__inner
+                    SOLD
 
       .productBox
         .productHead
-          = link_to "#", class:"link" do
-            %h3.topic
-              家電・スマホ・カメラ
-            .productList
-              - if @last_appliances_item == nil
-                %h3
-                  このカテゴリの新規投稿商品はありません。
-              - else
-                = link_to "#", class:"link" do
-                  %figure.productList--img
-                    = image_tag @last_appliances_item.images[0].image.url,size:"250x200" , alt:"商品写真"
-                .productList--body
-                  %h3.name
-                    = @last_appliances_item.name
-                  .details
-                    %ul
-                      %li
-                        = @last_appliances_item.price
-                      .en
-                      円
-                    %p.tax
-                      (税込)
-                -if @last_appliance_item.buyer_id.present? 
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner
-                      SOLD
+          %h3.topic
+            家電・スマホ・カメラ
+          .productList
+            - if @last_appliances_item == nil
+              %h3
+                このカテゴリの新規投稿商品はありません。
+            - else
+              = link_to item_path(@items), class:"link" do
+                %figure.productList--img
+                  = image_tag @last_appliances_item.images[0].image.url,size:"250x200" , alt:"商品写真"
+              .productList--body
+                %h3.name
+                  = @last_appliances_item.name
+                .details
+                  %ul
+                    %li
+                      = @last_appliances_item.price
+                    .en
+                    円
+                  %p.tax
+                    (税込)
+              -if @last_appliance_item.buyer_id.present? 
+                .items-box_photo__sold
+                  .items-box_photo__sold__inner
+                    SOLD
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     get 'addresses', to: 'users/registrations#new_address'
     post 'addresses', to: 'users/registrations#create_address'
   end
-    root 'items#index'
+  root 'items#index'
 
   resources :user, only: [:show]
 


### PR DESCRIPTION
What
商品一覧表示サーバーサイド実装完了。
ビューに、商品詳細画面へのリンクを追加記述。

Why
マージ後のコーデイングを効率よく行うため。
