### PR TITLE
[WIP]widthをminwidthにしてビュー崩れ防止

### DIFF
--- a/app/assets/stylesheets/card.new.scss
+++ b/app/assets/stylesheets/card.new.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   padding: 50px 0;
   .card-main__contents{
-    width: 700px;
+    min-width: 700px;
     border: 2px solid #00ffff;
     padding: 60px 60px;
   }


### PR DESCRIPTION
## What
カード登録画面の画面を縮めたら小さくなってしまう現象を防止
widthをminwidthに変更

## Why
ビュー崩れ防止の為